### PR TITLE
Update serialize.blacklist

### DIFF
--- a/src/main/resources/security/serialize.blacklist
+++ b/src/main/resources/security/serialize.blacklist
@@ -66,4 +66,3 @@ net.bytebuddy.dynamic.loading.ByteArrayClassLoader
 org.apache.commons.beanutils.BeanMap
 com.caucho.naming.QName
 com.sun.org.apache.xpath
-org.apache.commons.beanutils.BeanMap

--- a/src/main/resources/security/serialize.blacklist
+++ b/src/main/resources/security/serialize.blacklist
@@ -64,3 +64,6 @@ com.sun.org.apache.xml.internal.security.signature.XMLSignatureInput
 javassist.tools.web.Viewer
 net.bytebuddy.dynamic.loading.ByteArrayClassLoader
 org.apache.commons.beanutils.BeanMap
+com.caucho.naming.QName
+com.sun.org.apache.xpath
+org.apache.commons.beanutils.BeanMap


### PR DESCRIPTION
Fix missing Resin Gadget on internal blacklist accroding to marshalsec, add com.caucho.quercus package support。
related to https://github.com/alipay/sofa-hessian/issues/34